### PR TITLE
fix: sort decls by state number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asl-puml",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Generates a plant uml file from a valid JSON ASL file",
   "main": "./dist/index.js",
   "bin": {

--- a/src/__tests__/pumls/aws-example-dynamodb-semaphore.asl.puml
+++ b/src/__tests__/pumls/aws-example-dynamodb-semaphore.asl.puml
@@ -21,15 +21,6 @@ skinparam state {
     FontColor<<aslWait>> automatic
     BackgroundColor<<Compensate>> #orange
 }
-state "Do Work" as state2<<aslParallel>> {
-state "Branch 1" as state2_1 {
-state "Here" as state11<<aslPass>>
-state "You" as state12<<aslPass>>
-state "Do" as state13<<aslPass>>
-state "Work" as state14<<aslPass>>
-state "Run Lambda Function With \nControlled Concurrency" as state15<<aslTask>>
-}
-}
 state "Get Lock" as state1<<aslParallel>> {
 state "Branch 1" as state1_1 {
 state "Acquire Lock" as state5<<aslTask>>
@@ -43,6 +34,15 @@ state "Get Current Lock Record" as state7<<aslTask>>
 state "Check If Lock Already Acquired" as state8<<Choice>>
 state "Continue Because Lock Was \nAlready Acquired" as state9<<aslPass>>
 state "Wait to Get Lock" as state10<<aslWait>>
+}
+}
+state "Do Work" as state2<<aslParallel>> {
+state "Branch 1" as state2_1 {
+state "Here" as state11<<aslPass>>
+state "You" as state12<<aslPass>>
+state "Do" as state13<<aslPass>>
+state "Work" as state14<<aslPass>>
+state "Run Lambda Function With \nControlled Concurrency" as state15<<aslTask>>
 }
 }
 state "Release Lock" as state3<<aslTask>>

--- a/src/__tests__/pumls/aws-example-execute_athena_query.asl.puml
+++ b/src/__tests__/pumls/aws-example-execute_athena_query.asl.puml
@@ -18,14 +18,14 @@ skinparam state {
 }
 state "confirm_service_name" as state1<<Choice>>
 state "default_service_name" as state2<<aslPass>>
-state "get_athena_execution_status" as state7<<aslTask>>
-state "get_athena_query" as state4<<aslPass>>
-state "get_query_results" as state9<<aslTask>>
 state "handle_input" as state3<<aslPass>>
-state "is_query_finished" as state8<<Choice>>
-state "prepare_output_success" as state10<<aslPass>>
+state "get_athena_query" as state4<<aslPass>>
 state "start_athena_query" as state5<<aslTask>>
 state "wait_to_query" as state6<<aslWait>>
+state "get_athena_execution_status" as state7<<aslTask>>
+state "is_query_finished" as state8<<Choice>>
+state "get_query_results" as state9<<aslTask>>
+state "prepare_output_success" as state10<<aslPass>>
 [*] --> state1
 state1 --> state3
 state1 --> state2

--- a/src/__tests__/pumls/aws-example-ship-order-deadpath.asl.puml
+++ b/src/__tests__/pumls/aws-example-ship-order-deadpath.asl.puml
@@ -33,15 +33,10 @@ skinparam state {
     FontColor<<CustomStyle5>> gray
     BackgroundColor<<CustomStyle5>> #whitesmoke
 }
-state "Do Fraud Check" as state3<<Choice>>
-state "Initial: Get Customer Status" as state2<<CustomStyle1>>
-state "Initial: Notify Fraudulent \nCustomer" as state10<<CustomStyle3>>: <:warning:><:warning:><:white_check_mark:>
-state "Initial: Notify Invalid Input" as state13<<CustomStyle5>>
-state "Initial: Notify New Order" as state4<<CustomStyle5>>
 state "Initial: Validate Input" as state1<<Choice>>
-state "Order Shipped Successfully" as state12<<CustomStyle5>>
-state "Order Shipping Failed" as state11<<CustomStyle4>>
-state "Reserve: Notify Products \nReserved" as state6<<CustomStyle5>>
+state "Initial: Get Customer Status" as state2<<CustomStyle1>>
+state "Do Fraud Check" as state3<<Choice>>
+state "Initial: Notify New Order" as state4<<CustomStyle5>>
 state "Reserve: Products" as state5<<CustomStyle5>> {
 state "Reserve: Product" as state14<<CustomStyle5>>
 state "Choice" as state15<<Choice>>
@@ -49,9 +44,14 @@ state "Successful" as state16<<CustomStyle5>>
 state "Reserve: Notify Delayed" as state17<<CustomStyle5>>
 state "Wait for availability" as state18<<CustomStyle5>>
 }
-state "Ship: Notify Packaging and \nShipping Failed" as state9<<CustomStyle5>>
-state "Ship: Notify Successful \nShipping" as state8<<CustomStyle5>>
+state "Reserve: Notify Products \nReserved" as state6<<CustomStyle5>>
 state "Ship: Packaging and Shipping" as state7<<CustomStyle5>>
+state "Ship: Notify Successful \nShipping" as state8<<CustomStyle5>>
+state "Ship: Notify Packaging and \nShipping Failed" as state9<<CustomStyle5>>
+state "Initial: Notify Fraudulent \nCustomer" as state10<<CustomStyle3>>: <:warning:><:warning:><:white_check_mark:>
+state "Order Shipping Failed" as state11<<CustomStyle4>>
+state "Order Shipped Successfully" as state12<<CustomStyle5>>
+state "Initial: Notify Invalid Input" as state13<<CustomStyle5>>
 [*] --> state1
 state1 -[#lightgray]-> state13
 state1 --> state2

--- a/src/__tests__/pumls/aws-example-ship-order.asl.puml
+++ b/src/__tests__/pumls/aws-example-ship-order.asl.puml
@@ -47,15 +47,10 @@ skinparam state {
     FontColor<<CustomStyle12>> gray
     BackgroundColor<<CustomStyle12>> #whitesmoke
 }
-state "Do Fraud Check" as state3<<Choice>>
-state "Initial: Get Customer Status" as state2<<CustomStyle0>>
-state "Initial: Notify Fraudulent \nCustomer" as state10<<CustomStyle12>>
-state "Initial: Notify Invalid Input" as state13<<CustomStyle12>>
-state "Initial: Notify New Order" as state4<<CustomStyle2>>
 state "Initial: Validate Input" as state1<<Choice>>
-state "Order Shipped Successfully" as state12<<CustomStyle11>>
-state "Order Shipping Failed" as state11<<CustomStyle12>>
-state "Reserve: Notify Products \nReserved" as state6<<CustomStyle8>>
+state "Initial: Get Customer Status" as state2<<CustomStyle0>>
+state "Do Fraud Check" as state3<<Choice>>
+state "Initial: Notify New Order" as state4<<CustomStyle2>>
 state "Reserve: Products" as state5<<CustomStyle3>> {
 state "Reserve: Product" as state14<<CustomStyle4>>
 state "Choice" as state15<<Choice>>
@@ -63,9 +58,14 @@ state "Successful" as state16<<CustomStyle6>>
 state "Reserve: Notify Delayed" as state17<<CustomStyle7>>
 state "Wait for availability" as state18<<CustomStyle5>>
 }
-state "Ship: Notify Packaging and \nShipping Failed" as state9<<CustomStyle12>>
-state "Ship: Notify Successful \nShipping" as state8<<CustomStyle10>>
+state "Reserve: Notify Products \nReserved" as state6<<CustomStyle8>>
 state "Ship: Packaging and Shipping" as state7<<CustomStyle9>>
+state "Ship: Notify Successful \nShipping" as state8<<CustomStyle10>>
+state "Ship: Notify Packaging and \nShipping Failed" as state9<<CustomStyle12>>
+state "Initial: Notify Fraudulent \nCustomer" as state10<<CustomStyle12>>
+state "Order Shipping Failed" as state11<<CustomStyle12>>
+state "Order Shipped Successfully" as state12<<CustomStyle11>>
+state "Initial: Notify Invalid Input" as state13<<CustomStyle12>>
 [*] --> state1
 state1 -[#lightgray]-> state13
 state1 --> state2

--- a/src/__tests__/pumls/aws-example-test-result-recorder.asl.puml
+++ b/src/__tests__/pumls/aws-example-test-result-recorder.asl.puml
@@ -16,14 +16,14 @@ skinparam state {
     FontColor<<aslTask>> automatic
     BackgroundColor<<Compensate>> #orange
 }
-state "ClearResults" as state7<<aslPass>>
-state "ConfirmRequiredData" as state2<<Choice>>
 state "HandleInput" as state1<<aslTask>>
-state "InvalidInput" as state8<<aslFail>>
-state "RecordTestRun-DurationMetric" as state4<<aslTask>>
-state "RecordTestRun-DynamoDB" as state6<<aslTask>>
-state "RecordTestRun-StatusMetric" as state5<<aslTask>>
+state "ConfirmRequiredData" as state2<<Choice>>
 state "WasSuccessOrFailure" as state3<<Choice>>
+state "RecordTestRun-DurationMetric" as state4<<aslTask>>
+state "RecordTestRun-StatusMetric" as state5<<aslTask>>
+state "RecordTestRun-DynamoDB" as state6<<aslTask>>
+state "ClearResults" as state7<<aslPass>>
+state "InvalidInput" as state8<<aslFail>>
 [*] --> state1
 state1 --> state2
 state2 --> state3

--- a/src/__tests__/pumls/demo.asl.puml
+++ b/src/__tests__/pumls/demo.asl.puml
@@ -22,17 +22,17 @@ state "FulfillAsk" as state5<<aslTask>>
 state "FulfillFundAccount" as state6<<aslTask>>
 }
 state "Dispatch by type of item" as state1<<Choice>>
-state "Error" as state8<<aslFail>>
-state "MarkOrderAsFulfilled" as state7<<aslTask>>
-state "PrepareFulfillAskRequest" as state3<<aslPass>>
 state "PrepareFulfillWidgetRequest" as state2<<aslPass>>
+state "PrepareFulfillAskRequest" as state3<<aslPass>>
+state "MarkOrderAsFulfilled" as state7<<aslTask>>
+state "Error" as state8<<aslFail>>
+state "PublishOrderComplete" as state9<<aslTask>>
 state "PublishCompensate" as state10<<Compensate>>
 note left
   order will be canceled,
   payments refunded, and
   inventory released
 end note
-state "PublishOrderComplete" as state9<<aslTask>>
 [*] --> state1
 state1 --> state2
 note on link

--- a/src/__tests__/pumls/nested_maps.asl.puml
+++ b/src/__tests__/pumls/nested_maps.asl.puml
@@ -12,12 +12,12 @@ skinparam state {
     FontColor<<aslWait>> automatic
     BackgroundColor<<Compensate>> #orange
 }
-state "Final State" as state2<<aslSucceed>>
 state "Map" as state1<<aslMap>> {
 state "Map2" as state3<<aslMap>> {
 state "Wait 20s" as state4<<aslWait>>
 }
 }
+state "Final State" as state2<<aslSucceed>>
 [*] --> state1
 state1 --> state2
 state2 --> [*]

--- a/src/__tests__/pumls/parallel.asl.puml
+++ b/src/__tests__/pumls/parallel.asl.puml
@@ -15,7 +15,6 @@ skinparam state {
     FontColor<<aslWait>> automatic
     BackgroundColor<<Compensate>> #orange
 }
-state "Final State" as state2<<aslSucceed>>
 state "Parallel" as state1<<aslParallel>> {
 state "Branch 1" as state1_1 {
 state "Wait 20s" as state3<<aslWait>>
@@ -25,6 +24,7 @@ state "Pass" as state4<<aslPass>>
 state "Wait 10s" as state5<<aslWait>>
 }
 }
+state "Final State" as state2<<aslSucceed>>
 [*] --> state1
 state1 --> state2
 state1 -[bold,#orange]-> state2

--- a/src/__tests__/pumls/parallel_in_map.asl.puml
+++ b/src/__tests__/pumls/parallel_in_map.asl.puml
@@ -17,8 +17,6 @@ skinparam state {
     FontColor<<aslWait>> automatic
     BackgroundColor<<Compensate>> #orange
 }
-state "Error" as state2<<aslFail>>
-state "Final State" as state3<<aslSucceed>>
 state "Map" as state1<<aslMap>> {
 state "Parallel" as state4<<aslParallel>> {
 state "Branch 1" as state4_1 {
@@ -29,6 +27,8 @@ state "Wait 30s" as state6<<aslWait>>
 }
 }
 }
+state "Error" as state2<<aslFail>>
+state "Final State" as state3<<aslSucceed>>
 [*] --> state1
 state1 --> state3
 state1 -[#pink]-> state2

--- a/src/lib/decls.ts
+++ b/src/lib/decls.ts
@@ -153,7 +153,11 @@ export const decls: PumlBuilder = (_definition, state_map, config: Config) => {
       }
     });
 
-  const sorted = Array.from(state_map.keys()).sort();
+  const sorted = Array.from(state_map.keys()).sort((a, b) => {
+    const stateA = state_map.get(a) as StateHints;
+    const stateB = state_map.get(b) as StateHints;
+    return stateA.id - stateB.id;
+  });
   // emit containers first
   sorted
     .filter((key) => (state_map.get(key) as StateHints).parent === null)


### PR DESCRIPTION
closes #34 

simple fix to ensure the state decls are sorted before emitting the output

this doesn't address the use case where the source ASL is not ordered but it's good enough for now